### PR TITLE
Parallel processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ More information about the Jupyter notebook can be found here:
 
 ## Running the Scripts: ##
 
-When running the main script with parallel processing enabled, some system run into an issue with matplotlib, producing the following error:
+When running the scripts with parallel processing enabled, some system encounter the following error:
 
 ```
 The process has forked and you cannot use this CoreFoundation functionality safely. You MUST exec().
@@ -94,5 +94,5 @@ Find the line in this file where 'backend' is defined; it should look like this.
 ```
 backend      : TkAgg
 ```
-And comment out this line with #. This change sets the matplotlib backend to use the default non-interactive  version.
-Interactive versions of the matplotlib backend (like Tkinter based backend shown above) can cause issues with multiprocessing.
+Comment out this line with a leading '#'. This change sets the matplotlib backend to use the default non-interactive  version.
+Interactive versions of the matplotlib backend (like the Tkinter based backend shown above) can cause issues with multiprocessing.

--- a/README.md
+++ b/README.md
@@ -73,3 +73,26 @@ Click on the notebook you want to open.
 More information about the Jupyter notebook can be found here:
 
 * [Jupyter notebook documentation](https://jupyter-notebook.readthedocs.io/en/latest/index.html)
+
+## Running the Scripts: ##
+
+When running the main script with parallel processing enabled, some system run into an issue with matplotlib, producing the following error:
+
+```
+The process has forked and you cannot use this CoreFoundation functionality safely. You MUST exec().
+Break on __THE_PROCESS_HAS_FORKED_AND_YOU_CANNOT_USE_THIS_COREFOUNDATION_FUNCTIONALITY___YOU_MUST_EXEC__() to debug.
+```
+
+To fix this issue, find your _matplotlibrc_ file by going into the python environment you are using and running the commands:
+```python
+>>> import matplotlib
+>>> matplotlib.matplotlib_fname()
+'/home/foo/.config/matplotlib/matplotlibrc' # This output shows where your matplotlibrc file is located
+```
+
+Find the line in this file where 'backend' is defined; it should look like this.
+```
+backend      : TkAgg
+```
+And comment out this line with #. This change sets the matplotlib backend to use the default non-interactive  version.
+Interactive versions of the matplotlib backend (like Tkinter based backend shown above) can cause issues with multiprocessing.

--- a/scripts/ADF_SSN_03_ADF_all_Observers.py
+++ b/scripts/ADF_SSN_03_ADF_all_Observers.py
@@ -6,6 +6,7 @@ from SSN_ADF import ssnADF
 from SSN_Config import SSN_ADF_Config
 import SSN_ADF_Plotter
 import argparse
+from joblib import Parallel, delayed
 
 parser = argparse.ArgumentParser(description="Specify arguments for SSN/ADF config")
 parser.add_argument('-q',"--QDF", action='store_true')

--- a/scripts/SSN_ADF.py
+++ b/scripts/SSN_ADF.py
@@ -604,7 +604,7 @@ class ssnADF(ssn_data):
             # Perform analysis Only if the period is valid
             if ssn_data.vldIntr[siInx]:
 
-                print('Valid Interval')
+                print('[{}/{}] Valid Interval'.format(siInx+1, num_intervals))
 
                 # Defining mask based on the interval type (rise or decay)
                 if ssn_data.cenPoints['OBS'][siInx, 1] > 0:
@@ -692,7 +692,7 @@ class ssnADF(ssn_data):
 
             # If period is not valid append empty variables
             else:
-                print('INVALID Interval')
+                print('[{}/{}] INVALID Interval'.format(siInx+1, num_intervals))
                 EMD = []
                 EMDt = []
                 EMDth = []

--- a/scripts/SSN_ADF_Plotter.py
+++ b/scripts/SSN_ADF_Plotter.py
@@ -537,7 +537,7 @@ def plotOptimalThresholdWindow(SSN_data,
         # Plotting edges
         print(siInx, SSN_data.Clr)
         ax1.plot(np.array([1, 1]) * np.min(TObsFYr), np.array([0, np.max(y)]), ':', zorder=11, linewidth=3,
-                 color=SSN_data.Clr[np.mod(5 - siInx)])
+                 color=SSN_data.Clr[siInx % 6])
         ax1.plot(np.array([1, 1]) * np.max(TObsFYr), np.array([0, np.max(y)]), ':', zorder=11, linewidth=3,
                  color=SSN_data.Clr[siInx % 6])
 

--- a/scripts/SSN_Config.py
+++ b/scripts/SSN_Config.py
@@ -12,8 +12,14 @@ class SSN_ADF_Config:
     """
 
     # ADF/QDF and FULL/OBS default values
-    ADF_TYPE = "ADF"
-    MONTH_TYPE = "OBS"
+    ADF_TYPE = "QDF"
+    MONTH_TYPE = "FULLM"
+
+    # MULTI THREADING
+    THREADS = 1 # 1 -- do not use any parallel processing.
+                # -1 --  use all cores on machine.
+                # Otherwise -- number of cores to use.
+
 
     # Plotting config varibales
     PLOT_OPTIMAL_THRESH = True

--- a/scripts/SSN_Config.py
+++ b/scripts/SSN_Config.py
@@ -16,9 +16,9 @@ class SSN_ADF_Config:
     MONTH_TYPE = "FULLM"
 
     # MULTI THREADING
-    THREADS = 1 # 1 -- do not use any parallel processing.
+    PROCESSES = 1 # 1 -- do not use any parallel processing.
                 # -1 --  use all cores on machine.
-                # Otherwise -- number of cores to use.
+                # Otherwise -- defines number of cores to use.
 
 
     # Plotting config varibales


### PR DESCRIPTION
This commit uses the built in multiprocessing library to spread the load among different workers. This build seems to be stable, and I ended up running it on the Q_M_ flags and it ran much faster than with no parallelism. There is a variable in the config file to set the number of cores. 1 will always run the script like usual. -1 will run with all available cores. Otherwise use the number of cores set in the variable.